### PR TITLE
Experiment: switch to own concurrency backends

### DIFF
--- a/asgi_lifespan/concurrency/asyncio.py
+++ b/asgi_lifespan/concurrency/asyncio.py
@@ -1,0 +1,218 @@
+import asyncio
+import math
+import typing
+import types
+
+from async_generator import asynccontextmanager, aclosing
+
+from . import base
+
+T = typing.TypeVar("T")
+
+
+class AsyncioExceptionGroup(base.BaseExceptionGroup):
+    def __init__(self, exceptions: typing.Sequence[BaseException]):
+        super().__init__()
+        self.exceptions = exceptions
+
+
+class AsyncioConcurrencyBackend(base.BaseConcurrencyBackend):
+    def create_event(self) -> base.BaseEvent:
+        return Event()
+
+    def create_queue(self, capacity: int) -> base.BaseQueue:
+        return typing.cast(base.BaseQueue, asyncio.Queue(maxsize=capacity))
+
+    def create_task_group(self) -> "TaskGroup":
+        return TaskGroup()
+
+    def finalize(self, obj: T) -> typing.AsyncContextManager[T]:
+        return aclosing(obj)
+
+    def get_cancelled_exception_class(self) -> typing.Type[BaseException]:
+        return asyncio.CancelledError
+
+    @asynccontextmanager
+    async def move_on_after(
+        self, seconds: typing.Optional[float]
+    ) -> typing.AsyncIterator["CancelScope"]:
+        deadline = (
+            None if seconds is None else asyncio.get_running_loop().time() + seconds
+        )
+        async with CancelScope(deadline) as cancel_scope:
+            yield cancel_scope
+
+
+class Event(base.BaseEvent):
+    def __init__(self) -> None:
+        self._event = asyncio.Event()
+
+    async def set(self) -> None:
+        self._event.set()
+
+    async def wait(self) -> None:
+        await self._event.wait()
+
+
+class CancelScope(base.BaseCancelScope):
+    def __init__(self, deadline: float = None) -> None:
+        self._deadline = deadline
+        self._tasks: typing.Set[asyncio.Task] = set()
+        self._timeout_task: typing.Optional[asyncio.Task] = None
+        self._timeout_expired = False
+        self._cancel_called = False
+        self._active = False
+        self._host_task: typing.Optional[asyncio.Task] = None
+
+    @property
+    def timeout_expired(self) -> bool:
+        return self._timeout_expired
+
+    async def __aenter__(self) -> "CancelScope":
+        async def timeout() -> None:
+            cancel_after = (
+                math.inf
+                if self._deadline is None
+                else self._deadline - asyncio.get_running_loop().time()
+            )
+            await asyncio.sleep(cancel_after)
+            self._timeout_expired = True
+            await self.cancel()
+
+        assert (
+            not self._active
+        ), "A CancelScope can only be used for a single 'async with' block."
+
+        host_task = asyncio.current_task()
+        assert host_task is not None
+        self._host_task = host_task
+        self._tasks.add(self._host_task)
+
+        if self._deadline is not None:
+            assert (
+                asyncio.get_running_loop().time() < self._deadline
+            ), "Negative cancel delays aren't supported yet."
+            self._timeout_task = asyncio.get_running_loop().create_task(timeout())
+
+        self._active = True
+
+        return self
+
+    def add(self, task: asyncio.Task) -> None:
+        self._tasks.add(task)
+
+    def remove(self, task: asyncio.Task) -> None:
+        self._tasks.remove(task)
+
+    async def flush_tasks(self) -> None:
+        if not self._tasks:
+            return
+        done, pending = await asyncio.wait(self._tasks)
+        assert not pending
+
+    async def cancel(self) -> None:
+        if self._cancel_called:
+            return
+        self._cancel_called = True
+        await self._cancel()
+
+    async def _cancel(self) -> None:
+        # Deliver cancellation to directly contained tasks.
+        # NOTE: nested cancel scopes aren't supported.
+        for task in self._tasks:
+            coro: typing.Coroutine = task._coro  # type: ignore
+            is_running = coro.cr_await is not None
+            if is_running:
+                task.cancel()
+
+    async def __aexit__(
+        self,
+        exc_type: typing.Type[BaseException] = None,
+        exc_val: BaseException = None,
+        exc_tb: types.TracebackType = None,
+    ) -> typing.Optional[bool]:
+        self._active = False
+
+        if self._timeout_task:
+            self._timeout_task.cancel()
+
+        assert self._host_task is not None
+        self._tasks.remove(self._host_task)
+
+        if exc_val is not None:
+            exceptions = (
+                exc_val.exceptions
+                if isinstance(exc_val, base.BaseExceptionGroup)
+                else [exc_val]
+            )
+
+            if all(isinstance(exc, asyncio.CancelledError) for exc in exceptions):
+                if self._timeout_expired:
+                    return True
+
+        return False
+
+
+class TaskGroup(base.BaseTaskGroup):
+    def __init__(self) -> None:
+        self.cancel_scope = CancelScope()
+        self._active = False
+        self._exceptions: typing.List[BaseException] = []
+
+    async def _run_wrapped_task(
+        self, func: typing.Callable[..., typing.Coroutine], *args: typing.Any
+    ) -> None:
+        task = asyncio.current_task()
+        assert task is not None
+        try:
+            await func(*args)
+        except BaseException as exc:
+            self._exceptions.append(exc)
+            await self.cancel_scope.cancel()
+        finally:
+            self.cancel_scope.remove(task)
+
+    def start_soon(
+        self, func: typing.Callable[..., typing.Coroutine], *args: typing.Any
+    ) -> None:
+        assert self._active, (
+            "This task group is not active - no new tasks can be spawned. "
+            "To activate it, use 'async with task_group: ...'."
+        )
+        task = asyncio.create_task(self._run_wrapped_task(func, *args))
+        self.cancel_scope.add(task)
+
+    async def __aenter__(self) -> "TaskGroup":
+        await self.cancel_scope.__aenter__()
+        self._active = True
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: typing.Type[BaseException] = None,
+        exc_val: BaseException = None,
+        exc_tb: types.TracebackType = None,
+    ) -> typing.Optional[bool]:
+        ignore_exception = await self.cancel_scope.__aexit__(exc_type, exc_val, exc_tb)
+
+        if exc_val is not None:
+            await self.cancel_scope.cancel()
+            if not ignore_exception:
+                self._exceptions.append(exc_val)
+
+        await self.cancel_scope.flush_tasks()
+
+        self._active = False
+
+        exceptions = [
+            exc
+            for exc in self._exceptions
+            if not isinstance(exc, asyncio.CancelledError)
+        ]
+
+        if len(exceptions) > 1:
+            raise AsyncioExceptionGroup(exceptions)
+        if exceptions and exceptions[0] is not exc_val:
+            raise exceptions[0]
+
+        return ignore_exception

--- a/asgi_lifespan/concurrency/auto.py
+++ b/asgi_lifespan/concurrency/auto.py
@@ -1,0 +1,12 @@
+import sniffio
+
+from .base import BaseConcurrencyBackend
+
+
+def sniff_concurrency_backend() -> BaseConcurrencyBackend:
+    library = sniffio.current_async_library()
+    assert library == "asyncio", f"Async library {library} is not supported yet."
+
+    from .asyncio import AsyncioConcurrencyBackend
+
+    return AsyncioConcurrencyBackend()

--- a/asgi_lifespan/concurrency/base.py
+++ b/asgi_lifespan/concurrency/base.py
@@ -1,0 +1,98 @@
+import traceback
+import types
+import typing
+
+T = typing.TypeVar("T")
+
+
+class BaseConcurrencyBackend:
+    def create_event(self) -> "BaseEvent":
+        raise NotImplementedError  # pragma: no cover
+
+    def create_queue(self, capacity: int) -> "BaseQueue":
+        raise NotImplementedError  # pragma: no cover
+
+    def create_task_group(self) -> "BaseTaskGroup":
+        raise NotImplementedError  # pragma: no cover
+
+    def finalize(self, obj: T) -> typing.AsyncContextManager[T]:
+        raise NotImplementedError  # pragma: no cover
+
+    def get_cancelled_exception_class(self) -> typing.Type[BaseException]:
+        raise NotImplementedError  # pragma: no cover
+
+    def move_on_after(
+        self, seconds: typing.Optional[float]
+    ) -> typing.AsyncContextManager["BaseCancelScope"]:
+        raise NotImplementedError  # pragma: no cover
+
+
+class BaseEvent:
+    async def set(self) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+    async def wait(self) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+
+class BaseQueue:
+    async def get(self) -> typing.Any:
+        raise NotImplementedError  # pragma: no cover
+
+    async def put(self, value: typing.Any) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+
+class BaseAsyncContextManager:
+    async def __aenter__(self: T) -> T:
+        raise NotImplementedError  # pragma: no cover
+
+    async def __aexit__(
+        self,
+        exc_type: typing.Type[BaseException] = None,
+        exc_val: BaseException = None,
+        exc_tb: types.TracebackType = None,
+    ) -> typing.Optional[bool]:
+        raise NotImplementedError  # pragma: no cover
+
+
+class BaseCancelScope(BaseAsyncContextManager):
+    @property
+    def deadline(self) -> typing.Optional[float]:
+        raise NotImplementedError  # pragma: no cover
+
+    @property
+    def timeout_expired(self) -> bool:
+        raise NotImplementedError  # pragma: no cover
+
+    async def cancel(self) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+
+class BaseTaskGroup(BaseAsyncContextManager):
+    def start_soon(
+        self, func: typing.Callable[..., typing.Coroutine], *args: typing.Any
+    ) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+
+class BaseExceptionGroup(BaseException):
+    """Raised when multiple exceptions have been raised in a task group."""
+
+    SEPARATOR = "----------------------------\n"
+
+    exceptions: typing.Sequence[BaseException]
+
+    def __str__(self) -> str:
+        tracebacks = [
+            "\n".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+            for exc in self.exceptions
+        ]
+        return "{} exceptions were raised in the task group:\n{}{}".format(
+            len(self.exceptions), self.SEPARATOR, self.SEPARATOR.join(tracebacks)
+        )
+
+    def __repr__(self) -> str:
+        return "<{} ({} exceptions)>".format(
+            self.__class__.__name__, len(self.exceptions)
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ isort
 mypy
 nox
 pytest
+pytest-asyncio
 pytest-cov
 trio

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ combine_as_imports = True
 force_grid_wrap = 0
 include_trailing_comma = True
 known_first_party = asgi_lifespan,tests
-known_third_party = anyio,nox,pytest,setuptools
+known_third_party = nox,pytest,setuptools
 line_length = 88
 multi_line_output = 3
 
@@ -21,4 +21,3 @@ addopts =
   --cov=asgi_lifespan
   --cov=tests
   --cov-report=term-missing
-  --anyio-backends=asyncio,trio,curio

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
     author_email="florimond.manca@gmail.com",
     packages=get_packages("asgi_lifespan"),
     install_requires=[
-        "anyio",
         "async_generator; python_version < '3.7'",
         "async_exit_stack; python_version < '3.7'",
     ],

--- a/tests/concurrency.py
+++ b/tests/concurrency.py
@@ -1,0 +1,17 @@
+import asyncio
+import functools
+
+from asgi_lifespan.concurrency.base import BaseConcurrencyBackend
+from asgi_lifespan.concurrency.asyncio import AsyncioConcurrencyBackend
+
+
+@functools.singledispatch
+async def sleep(concurrency_backend: BaseConcurrencyBackend, seconds: int) -> None:
+    raise NotImplementedError  # pragma: no cover
+
+
+@sleep.register(AsyncioConcurrencyBackend)
+async def _sleep_asyncio(
+    concurrency_backend: AsyncioConcurrencyBackend, seconds: int
+) -> None:
+    await asyncio.sleep(seconds)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import typing
+
+import pytest
+
+from asgi_lifespan.concurrency.base import BaseConcurrencyBackend
+from asgi_lifespan.concurrency.asyncio import AsyncioConcurrencyBackend
+
+
+@pytest.fixture(
+    params=[pytest.param(AsyncioConcurrencyBackend, marks=pytest.mark.asyncio)]
+)
+def concurrency_backend(request: typing.Any) -> BaseConcurrencyBackend:
+    cls = request.param
+    return cls()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -56,9 +56,9 @@ def build_asgi_arguments(
     return scope, receive, send
 
 
-@pytest.mark.anyio
 @pytest.mark.parametrize("startup_failed", (False, True))
-async def test_lifespan_app(startup_failed: bool,) -> None:
+@pytest.mark.usefixtures("concurrency_backend")
+async def test_lifespan_app(startup_failed: bool) -> None:
     log: Log = []
     messages = [{"type": "lifespan.shutdown"}, {"type": "lifespan.startup"}]
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,27 @@
+import pytest
+
+from asgi_lifespan.concurrency.asyncio import (
+    AsyncioConcurrencyBackend,
+    AsyncioExceptionGroup,
+)
+
+
+@pytest.mark.asyncio
+async def test_task_group_multiple_exceptions() -> None:
+    backend = AsyncioConcurrencyBackend()
+
+    async def task1() -> None:
+        raise RuntimeError("Oops 1")
+
+    async def task2() -> None:
+        raise RuntimeError("Oops 2")
+
+    with pytest.raises(AsyncioExceptionGroup) as ctx:
+        async with backend.create_task_group() as task_group:
+            task_group.start_soon(task1)
+            task_group.start_soon(task2)
+
+    assert repr(ctx.value) == "<AsyncioExceptionGroup (2 exceptions)>"
+    assert [str(exc) for exc in ctx.value.exceptions] == ["Oops 1", "Oops 2"]
+    assert "Oops 1" in str(ctx.value)
+    assert "Oops 2" in str(ctx.value)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -5,7 +5,7 @@ import pytest
 from asgi_lifespan import LifespanMiddleware
 
 
-@pytest.mark.anyio
+@pytest.mark.usefixtures("concurrency_backend")
 async def test_lifespan_middleware() -> None:
     scopes: typing.List[dict] = []
 


### PR DESCRIPTION
This is an experiment of what we'd have had to implement if we didn't use `anyio`.

Note: only asyncio is implemented here.