### PR TITLE
Refactor LifespanManager

### DIFF
--- a/asgi_lifespan/_concurrency/base.py
+++ b/asgi_lifespan/_concurrency/base.py
@@ -31,23 +31,7 @@ class ConcurrencyBackend:
     ) -> None:
         raise NotImplementedError  # pragma: no cover
 
-    def finalize(
-        self, agen: typing.AsyncGenerator[None, None]
-    ) -> typing.AsyncContextManager:
-        return Finalize(agen)
-
     def run_in_background(
         self, coroutine: typing.Callable[[], typing.Awaitable[None]]
     ) -> typing.AsyncContextManager:
         raise NotImplementedError  # pragma: no cover
-
-
-class Finalize:
-    def __init__(self, agen: typing.AsyncGenerator):
-        self._agen = agen
-
-    async def __aenter__(self) -> typing.AsyncGenerator:
-        return self._agen
-
-    async def __aexit__(self, *args: typing.Any) -> None:
-        await self._agen.aclose()

--- a/asgi_lifespan/_concurrency/trio.py
+++ b/asgi_lifespan/_concurrency/trio.py
@@ -69,9 +69,4 @@ class Background:
         exc_value: BaseException = None,
         traceback: types.TracebackType = None,
     ) -> None:
-        try:
-            await self._exit_stack.__aexit__(exc_type, exc_value, traceback)
-        except trio.MultiError as exc:
-            for exception in exc.exceptions:
-                if not isinstance(exception, (trio.Cancelled, GeneratorExit)):
-                    raise exception
+        await self._exit_stack.__aexit__(exc_type, exc_value, traceback)

--- a/asgi_lifespan/compat.py
+++ b/asgi_lifespan/compat.py
@@ -1,9 +1,4 @@
 try:
-    from contextlib import asynccontextmanager
-except ImportError:  # pragma: no cover
-    from async_generator import asynccontextmanager  # type: ignore # noqa: F401
-
-try:
     from contextlib import AsyncExitStack
 except ImportError:  # pragma: no cover
     from async_exit_stack import AsyncExitStack  # type: ignore # noqa: F401

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,7 @@ setup(
     author="Florimond Manca",
     author_email="florimond.manca@gmail.com",
     packages=get_packages("asgi_lifespan"),
-    install_requires=[
-        "async_generator; python_version < '3.7'",
-        "async_exit_stack; python_version < '3.7'",
-    ],
+    install_requires=["async_exit_stack; python_version < '3.7'",],
     include_package_data=True,
     package_data={"asgi_lifespan": ["py.typed"]},
     zip_safe=False,

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -65,7 +65,7 @@ async def test_lifespan_manager(
             stack.enter_context(pytest.raises(shutdown_exception))
 
         async with LifespanManager(app) as ctx:
-            # NOTE: this block will not execute in case of startup exception.
+            # NOTE: this block should not execute in case of startup exception.
             assert ctx is None
             assert not startup_exception
             assert received_lifespan_events == ["lifespan.startup"]


### PR DESCRIPTION
Get rid of generators and `@asynccontextmanager` in favor of plain class-based async context managers.