### PR TITLE
Improve auto-detection of async environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Modular components for adding [lifespan protocol](https://asgi.readthedocs.io/en
 - Add lifespan support to an ASGI app using `LifespanMiddleware`.
 - Send lifespan events to an ASGI app (e.g. for testing) using `LifespanManager`.
 - Support for [asyncio] and [trio].
-- No hard dependencies.
 - Fully type-annotated.
 - 100% test coverage.
 

--- a/asgi_lifespan/_concurrency/__init__.py
+++ b/asgi_lifespan/_concurrency/__init__.py
@@ -1,22 +1,57 @@
+import sys
+
 from .base import ConcurrencyBackend
 
 
+def _is_already_imported(module: str) -> bool:
+    return module in sys.modules
+
+
+def sniff_async_library() -> str:
+    # Adapted from:
+    # https://github.com/python-trio/sniffio/blob/master/sniffio/_impl.py
+
+    if _is_already_imported("asyncio"):
+        import asyncio
+
+        try:
+            current_task = asyncio.current_task
+        except AttributeError:
+            current_task = asyncio.Task.current_task
+
+        try:
+            task = current_task()
+        except RuntimeError:
+            pass
+        else:
+            if task is not None:
+                return "asyncio"
+
+    if _is_already_imported("trio"):
+        import trio
+
+        try:
+            task = trio.hazmat.current_task()
+        except RuntimeError:
+            pass
+        else:
+            assert task is not None
+            return "trio"
+
+    raise NotImplementedError(
+        "Unknown async library, or not in async context."
+    )  # pragma: no cover
+
+
 def detect_concurrency_backend() -> ConcurrencyBackend:
-    from .asyncio import AsyncioBackend
-
-    try:
-        import sniffio
-    except ImportError:  # pragma: no cover
-        # sniffio would have been installed with trio,
-        # so we must be running on asyncio.
-        return AsyncioBackend()
-
-    library = sniffio.current_async_library()
+    library = sniff_async_library()
     assert library in ("asyncio", "trio")
 
-    if library == "asyncio":
+    if library == "trio":
+        from .trio import TrioBackend
+
+        return TrioBackend()
+    else:
+        from .asyncio import AsyncioBackend
+
         return AsyncioBackend()
-
-    from .trio import TrioBackend
-
-    return TrioBackend()

--- a/asgi_lifespan/_concurrency/__init__.py
+++ b/asgi_lifespan/_concurrency/__init__.py
@@ -1,57 +1,20 @@
-import sys
+import sniffio
 
 from .base import ConcurrencyBackend
 
 
-def _is_already_imported(module: str) -> bool:
-    return module in sys.modules
-
-
-def sniff_async_library() -> str:
-    # Adapted from:
-    # https://github.com/python-trio/sniffio/blob/master/sniffio/_impl.py
-
-    if _is_already_imported("asyncio"):
-        import asyncio
-
-        try:
-            current_task = asyncio.current_task
-        except AttributeError:
-            current_task = asyncio.Task.current_task
-
-        try:
-            task = current_task()
-        except RuntimeError:
-            pass
-        else:
-            if task is not None:
-                return "asyncio"
-
-    if _is_already_imported("trio"):
-        import trio
-
-        try:
-            task = trio.hazmat.current_task()
-        except RuntimeError:
-            pass
-        else:
-            assert task is not None
-            return "trio"
-
-    raise NotImplementedError(
-        "Unknown async library, or not in async context."
-    )  # pragma: no cover
-
-
 def detect_concurrency_backend() -> ConcurrencyBackend:
-    library = sniff_async_library()
-    assert library in ("asyncio", "trio")
+    library = sniffio.current_async_library()
 
-    if library == "trio":
-        from .trio import TrioBackend
-
-        return TrioBackend()
-    else:
+    if library == "asyncio":
         from .asyncio import AsyncioBackend
 
         return AsyncioBackend()
+    elif library == "trio":
+        from .trio import TrioBackend
+
+        return TrioBackend()
+
+    raise NotImplementedError(
+        f"Unsupported async library: {library}"
+    )  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     author="Florimond Manca",
     author_email="florimond.manca@gmail.com",
     packages=get_packages("asgi_lifespan"),
-    install_requires=["async_exit_stack; python_version < '3.7'",],
+    install_requires=["sniffio", "async_exit_stack; python_version < '3.7'"],
     include_package_data=True,
     package_data={"asgi_lifespan": ["py.typed"]},
     zip_safe=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,8 @@ import pytest
 
 @pytest.fixture(
     params=[
-        pytest.param(None, marks=pytest.mark.asyncio),
-        pytest.param(None, marks=pytest.mark.trio),
+        pytest.param("asyncio", marks=pytest.mark.asyncio),
+        pytest.param("trio", marks=pytest.mark.trio),
     ]
 )
 def concurrency() -> None:


### PR DESCRIPTION
~Async auto-detection was brittle, as it was basically using `trio` if `sniffio` was installed, and `asyncio` otherwise. (But users might have `sniffio` installed and be running in an asyncio environment…).~

~So, use the same ideas than `sniffio`. (Not decided on using it yet, for the sake of staying no-dependencies.)~

Switch to `sniffio` for detecting the concurrency backend.