### PR TITLE
Build tags

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -8,6 +8,7 @@ resources:
 
 trigger:
   - master
+  - refs/tags/*
 
 pr:
   - master


### PR DESCRIPTION
#36 failed to be published on tag (via #37) because the CI was configured to only run on pushes to `master`.