### PR TITLE
seed-isort-config is obsolete

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,5 @@ pytest
 pytest-asyncio
 pytest-cov
 pytest-trio
-seed-isort-config
 starlette==0.13.*
 trio

--- a/scripts/lint
+++ b/scripts/lint
@@ -9,6 +9,5 @@ export SOURCE_FILES="src tests"
 set -x
 
 ${PREFIX}autoflake --in-place --recursive $SOURCE_FILES
-${PREFIX}seed-isort-config --application-directories=src
 ${PREFIX}isort $SOURCE_FILES
 ${PREFIX}black --target-version=py36 $SOURCE_FILES


### PR DESCRIPTION
According to https://github.com/asottile-archive/seed-isort-config
seed-isort-config is no longer needed as of isort>=5
