### PR TITLE
run no_implicit_optional

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -29,7 +29,6 @@ stages:
       - template: job--python-test.yml@templates
         parameters:
           jobs:
-            py36:
             py37:
             py38:
               coverage: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ flake8
 flake8-bugbear
 flake8-comprehensions
 isort==5.*
-mypy
+mypy==0.990
 pytest
 pytest-asyncio
 pytest-cov

--- a/src/asgi_lifespan/_concurrency/asyncio.py
+++ b/src/asgi_lifespan/_concurrency/asyncio.py
@@ -68,8 +68,8 @@ class Background:
     async def __aexit__(
         self,
         exc_type: typing.Optional[typing.Type[BaseException]] = None,
-        exc_value: BaseException = None,
-        traceback: types.TracebackType = None,
+        exc_value: typing.Optional[BaseException] = None,
+        traceback: typing.Optional[types.TracebackType] = None,
     ) -> None:
         assert self.task is not None
 

--- a/src/asgi_lifespan/_concurrency/trio.py
+++ b/src/asgi_lifespan/_concurrency/trio.py
@@ -66,7 +66,7 @@ class Background:
     async def __aexit__(
         self,
         exc_type: typing.Optional[typing.Type[BaseException]] = None,
-        exc_value: BaseException = None,
-        traceback: types.TracebackType = None,
+        exc_value: typing.Optional[BaseException] = None,
+        traceback: typing.Optional[types.TracebackType] = None,
     ) -> None:
         await self._exit_stack.__aexit__(exc_type, exc_value, traceback)

--- a/src/asgi_lifespan/_manager.py
+++ b/src/asgi_lifespan/_manager.py
@@ -94,9 +94,9 @@ class LifespanManager:
 
     async def __aexit__(
         self,
-        exc_type: typing.Type[BaseException] = None,
-        exc_value: BaseException = None,
-        traceback: TracebackType = None,
+        exc_type: typing.Optional[typing.Type[BaseException]] = None,
+        exc_value: typing.Optional[BaseException] = None,
+        traceback: typing.Optional[TracebackType] = None,
     ) -> typing.Optional[bool]:
         if exc_type is None:
             self._exit_stack.push_async_callback(self.shutdown)


### PR DESCRIPTION
`mypy` has recently [disabled implicit `Optional` by default](https://github.com/python/mypy/issues/9091) (so `def f(x: int = None):` is no longer allowed)

They created a tool, [no_implicit_optional](https://github.com/hauntsaninja/no_implicit_optional), to auto-modify code.

However, I found that since my app's tests use asgi-lifespan, I cannot just run the `no_implicit_optional` tool on my own code. Since `mypy` now defaults to `implicit_optional = False`, this results in wrong typing for `asgi_lifespan.LifespanManager`. `mypy` then complains about my own correct use of `LifespanManager`.

For now, I'm working around my use of `LifespanManager` with `# type: ignore`, but it would be nice to make asgi-lifespan use strict `Optional`.

Before:

```
$ mypy .
src/asgi_lifespan/_concurrency/trio.py:54: error: Incompatible return value type (got "Background", expected "AbstractAsyncContextManager[Any]")  [return-value]
src/asgi_lifespan/_concurrency/trio.py:54: note: Following member(s) of "Background" have conflicts:
src/asgi_lifespan/_concurrency/trio.py:54: note:     Expected:
src/asgi_lifespan/_concurrency/trio.py:54: note:         def __aexit__(self, Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType], /) -> Coroutine[Any, Any, Optional[bool]]
src/asgi_lifespan/_concurrency/trio.py:54: note:     Got:
src/asgi_lifespan/_concurrency/trio.py:54: note:         def __aexit__(self, exc_type: Optional[Type[BaseException]] = ..., exc_value: BaseException = ..., traceback: TracebackType = ...) -> Coroutine[Any, Any, None]
src/asgi_lifespan/_concurrency/trio.py:69: error: Incompatible default for argument "exc_value" (default has type "None", argument has type "BaseException")  [assignment]
src/asgi_lifespan/_concurrency/trio.py:69: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
src/asgi_lifespan/_concurrency/trio.py:69: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
src/asgi_lifespan/_concurrency/trio.py:70: error: Incompatible default for argument "traceback" (default has type "None", argument has type "TracebackType")  [assignment]
src/asgi_lifespan/_concurrency/trio.py:70: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
src/asgi_lifespan/_concurrency/trio.py:70: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
src/asgi_lifespan/_concurrency/asyncio.py:51: error: Incompatible return value type (got "Background", expected "AbstractAsyncContextManager[Any]")  [return-value]
src/asgi_lifespan/_concurrency/asyncio.py:51: note: Following member(s) of "Background" have conflicts:
src/asgi_lifespan/_concurrency/asyncio.py:51: note:     Expected:
src/asgi_lifespan/_concurrency/asyncio.py:51: note:         def __aexit__(self, Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType], /) -> Coroutine[Any, Any, Optional[bool]]
src/asgi_lifespan/_concurrency/asyncio.py:51: note:     Got:
src/asgi_lifespan/_concurrency/asyncio.py:51: note:         def __aexit__(self, exc_type: Optional[Type[BaseException]] = ..., exc_value: BaseException = ..., traceback: TracebackType = ...) -> Coroutine[Any, Any, None]
src/asgi_lifespan/_concurrency/asyncio.py:71: error: Incompatible default for argument "exc_value" (default has type "None", argument has type "BaseException")  [assignment]
src/asgi_lifespan/_concurrency/asyncio.py:71: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
src/asgi_lifespan/_concurrency/asyncio.py:71: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
src/asgi_lifespan/_concurrency/asyncio.py:72: error: Incompatible default for argument "traceback" (default has type "None", argument has type "TracebackType")  [assignment]
src/asgi_lifespan/_concurrency/asyncio.py:72: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
src/asgi_lifespan/_concurrency/asyncio.py:72: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
src/asgi_lifespan/_manager.py:97: error: Incompatible default for argument "exc_type" (default has type "None", argument has type "Type[BaseException]")  [assignment]
src/asgi_lifespan/_manager.py:97: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
src/asgi_lifespan/_manager.py:97: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
src/asgi_lifespan/_manager.py:98: error: Incompatible default for argument "exc_value" (default has type "None", argument has type "BaseException")  [assignment]
src/asgi_lifespan/_manager.py:98: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
src/asgi_lifespan/_manager.py:98: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
src/asgi_lifespan/_manager.py:99: error: Incompatible default for argument "traceback" (default has type "None", argument has type "TracebackType")  [assignment]
src/asgi_lifespan/_manager.py:99: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
src/asgi_lifespan/_manager.py:99: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
```
I ran:
```
$ no_implicit_optional .
Calculating full-repo metadata...
Executing codemod...
Finished codemodding 15 files!
 - Transformed 15 files successfully.
 - Skipped 0 files.
 - Failed to codemod 0 files.
 - 0 warnings were generated.
$ isort  src/ tests/
Fixing /home/amnesia/Persistent/checkout/asgi-lifespan/src/asgi_lifespan/_manager.py
Fixing /home/amnesia/Persistent/checkout/asgi-lifespan/src/asgi_lifespan/_concurrency/trio.py
Fixing /home/amnesia/Persistent/checkout/asgi-lifespan/src/asgi_lifespan/_concurrency/asyncio.py
```
After:
```
$ mypy .
Success: no issues found in 15 source files
```