### PR TITLE
Expose lifespan state similarly to Starlette’s `TestClient`

### DIFF
--- a/src/asgi_lifespan/_manager.py
+++ b/src/asgi_lifespan/_manager.py
@@ -22,8 +22,8 @@ class LifespanManager:
         startup_timeout: typing.Optional[float] = 5,
         shutdown_timeout: typing.Optional[float] = 5,
     ) -> None:
-        self.app_state: typing.Dict[str, typing.Any] = {}
-        self.app = state_middleware(app, self.app_state)
+        self._state: typing.Dict[str, typing.Any] = {}
+        self.app = state_middleware(app, self._state)
         self.startup_timeout = startup_timeout
         self.shutdown_timeout = shutdown_timeout
 
@@ -89,6 +89,10 @@ class LifespanManager:
                 ) from exc
 
             raise
+
+    @property
+    def app_state(self) -> typing.Dict[str, typing.Any]:
+        return self._state
 
     async def __aenter__(self) -> "LifespanManager":
         await self._exit_stack.__aenter__()


### PR DESCRIPTION
Hello! This was already mentioned in #66, and I’d like to suggest this pr that exposes the lifespan state in a similar way to how it’s done in the [starlette framework in their `TestClient`](https://github.com/encode/starlette/blob/6ee94f2cac955eeae68d2898a8dec8cf17b48736/starlette/testclient.py#L399). 