### PR TITLE
Fix compatibility with Starlette 1.0

### DIFF
--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -40,26 +40,19 @@ async def test_lifespan_manager(
 ) -> None:
     # Setup failing event handlers.
 
-    on_startup: list = []
-    on_shutdown: list = []
-
-    if startup_exception is not None:
-
-        async def startup() -> None:
+    @contextlib.asynccontextmanager
+    async def lifespan(app):
+        if startup_exception is not None:
             assert startup_exception is not None  # Please mypy.
             raise startup_exception()
+        try:
+            yield
+        finally:
+            if shutdown_exception is not None:
+                assert shutdown_exception is not None  # Please mypy.
+                raise shutdown_exception()
 
-        on_startup.append(startup)
-
-    if shutdown_exception is not None:
-
-        async def shutdown() -> None:
-            assert shutdown_exception is not None  # Please mypy.
-            raise shutdown_exception()
-
-        on_shutdown.append(shutdown)
-
-    router = Router(on_startup=on_startup, on_shutdown=on_shutdown)
+    router = Router(lifespan=lifespan)
 
     # Set up spying on exchanged ASGI events.
 


### PR DESCRIPTION
(The patch on this PR was generated with Claude)

The autopkgtest for asgi-lifespan has been failing since Starlette was updated to 1.0 in Debian. Starlette 1.0 removed the `on_startup` and `on_shutdown` parameters from `Router` , along with other long-deprecated APIs, in favor of the `lifespan` async context manager pattern. The test suite was still using the old parameters, which caused the regression.

Since I don't have enough time to dig through the internals myself, I gave Claude a chance to investigate and propose a fix. I've reviewed everything in this PR.

The things I did to lower the chances of mistakes:

(1) Grounded the agent in the actual error, shared the failing test output and the Starlette 1.0 release notes confirming the removal.
(2) Kept the change minimal, the agent's first proposal was correct, then a second test run caught a failure in the `body_exception + shutdown_exception` case, which led to adding `try/finally` to ensure shutdown handlers always run.

Closes #71 